### PR TITLE
Enables toasts to be used with react components and elements

### DIFF
--- a/src/components/toast-bar.tsx
+++ b/src/components/toast-bar.tsx
@@ -124,6 +124,8 @@ export const ToastBar: React.FC<ToastBarProps> = React.memo(
       return <Indicator theme={iconTheme} type={type} />;
     };
 
+    const DataToRender = resolveValueOrFunction(toast.message, toast)
+
     return (
       <div
         style={{
@@ -142,7 +144,7 @@ export const ToastBar: React.FC<ToastBarProps> = React.memo(
         >
           {renderIcon()}
           <Message role={toast.role} aria-live={toast.ariaLive}>
-            {resolveValueOrFunction(toast.message, toast)}
+            {typeof DataToRender === 'function' ? React.createElement(DataToRender, null, null) : DataToRender}
           </Message>
         </ToastBarBase>
       </div>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,7 +24,7 @@ export type ValueOrFunction<TValue, TArg> =
 const isFunction = <TValue, TArg>(
   valOrFunction: ValueOrFunction<TValue, TArg>
 ): valOrFunction is ValueFunction<TValue, TArg> =>
-  typeof valOrFunction === 'function';
+  typeof valOrFunction === 'function' && !(String(valOrFunction).includes('createElement') || !valOrFunction.prototype.isReactComponent);
 
 export const resolveValueOrFunction = <TValue, TArg>(
   valOrFunction: ValueOrFunction<TValue, TArg>,


### PR DESCRIPTION
Instead of completely replacing the <Message> component, I thought it would be better to use it as a wrapper around whatever the user passes in their toast 

To achieve that I made some additions to the conditions of the 'isFunction' function so that it returns false whenever it encounters a react component or element. This way, if the 'resolvedValueOrFunction' function is passed a component or element (either function or class) it will simply return it as it was passed. 

What the conditional within the Message component does is check the type of the result from the 'resolvedValueOrFunction' function. If the result is a primitive value, it returns it; Also, if the result is a react element-which is a UI descriptor object-it is also returned since its type is not a function. However, if the result is a react component then it reconciles it.

The reason I used React.createElement instead of <DataToRender /> was because I was getting an error in the compiler. Nonetheless, since JSX compiles to React.createElement it should work.