### PR TITLE
Fix auto-remove not working in toast.dismiss()

### DIFF
--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -7,7 +7,7 @@ import {
   ValueOrFunction,
   resolveValueOrFunction,
 } from './types';
-import { genId } from './utils';
+import { genId, dismissToast } from './utils';
 import { dispatch, ActionType } from './store';
 
 type Message = ValueOrFunction<Renderable, Toast>;
@@ -46,15 +46,7 @@ toast.error = createHandler('error');
 toast.success = createHandler('success');
 toast.loading = createHandler('loading');
 
-toast.dismiss = (toastId?: string) => {
-  dispatch({ type: ActionType.DISMISS_TOAST, toastId });
-  setTimeout(() => {
-    dispatch({
-      type: ActionType.REMOVE_TOAST,
-      toastId,
-    });
-  }, 1000);
-};
+toast.dismiss = (toastId?: string) => dismissToast(toastId);
 
 toast.remove = (toastId?: string) =>
   dispatch({ type: ActionType.REMOVE_TOAST, toastId });

--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -7,7 +7,7 @@ import {
   ValueOrFunction,
   resolveValueOrFunction,
 } from './types';
-import { genId, dismissToast } from './utils';
+import { genId } from './utils';
 import { dispatch, ActionType } from './store';
 
 type Message = ValueOrFunction<Renderable, Toast>;
@@ -46,7 +46,18 @@ toast.error = createHandler('error');
 toast.success = createHandler('success');
 toast.loading = createHandler('loading');
 
-toast.dismiss = (toastId?: string) => dismissToast(toastId);
+toast.dismiss = (toastId?: string) => {
+  dispatch({
+    type: ActionType.DISMISS_TOAST,
+    toastId,
+  });
+  setTimeout(() => {
+    dispatch({
+      type: ActionType.REMOVE_TOAST,
+      toastId,
+    });
+  }, 1000);
+};
 
 toast.remove = (toastId?: string) =>
   dispatch({ type: ActionType.REMOVE_TOAST, toastId });

--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -46,8 +46,16 @@ toast.error = createHandler('error');
 toast.success = createHandler('success');
 toast.loading = createHandler('loading');
 
-toast.dismiss = (toastId?: string) =>
+toast.dismiss = (toastId?: string) => {
   dispatch({ type: ActionType.DISMISS_TOAST, toastId });
+  setTimeout(() => {
+    dispatch({
+      type: ActionType.REMOVE_TOAST,
+      toastId,
+    });
+  }, 1000);
+};
+
 toast.remove = (toastId?: string) =>
   dispatch({ type: ActionType.REMOVE_TOAST, toastId });
 

--- a/src/core/use-toaster.ts
+++ b/src/core/use-toaster.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { dispatch, ActionType, useStore } from './store';
+import { toast } from './toast';
 import { DefaultToastOptions } from './types';
-import { dismissToast } from './utils';
 
 export const useToaster = (toastOptions?: DefaultToastOptions) => {
   const { toasts, pausedAt } = useStore(toastOptions);
@@ -19,11 +19,11 @@ export const useToaster = (toastOptions?: DefaultToastOptions) => {
 
       if (durationLeft < 0) {
         if (t.visible) {
-          dismissToast(t.id);
+          toast.dismiss(t.id);
         }
         return;
       }
-      return setTimeout(() => dismissToast(t.id), durationLeft);
+      return setTimeout(() => toast.dismiss(t.id), durationLeft);
     });
 
     return () => {

--- a/src/core/use-toaster.ts
+++ b/src/core/use-toaster.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { dispatch, ActionType, useStore } from './store';
 import { DefaultToastOptions } from './types';
+import { dismissToast } from './utils';
 
 export const useToaster = (toastOptions?: DefaultToastOptions) => {
   const { toasts, pausedAt } = useStore(toastOptions);
@@ -16,26 +17,13 @@ export const useToaster = (toastOptions?: DefaultToastOptions) => {
       const durationLeft =
         (t.duration || 0) + t.pauseDuration - (now - t.createdAt);
 
-      const dismiss = () => {
-        dispatch({
-          type: ActionType.DISMISS_TOAST,
-          toastId: t.id,
-        });
-        setTimeout(() => {
-          dispatch({
-            type: ActionType.REMOVE_TOAST,
-            toastId: t.id,
-          });
-        }, 1000);
-      };
-
       if (durationLeft < 0) {
         if (t.visible) {
-          dismiss();
+          dismissToast(t.id);
         }
         return;
       }
-      return setTimeout(dismiss, durationLeft);
+      return setTimeout(() => dismissToast(t.id), durationLeft);
     });
 
     return () => {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,6 +1,21 @@
+import { dispatch, ActionType } from './store';
+
 export const genId = (() => {
   let count = 0;
   return () => {
     return (++count).toString();
   };
 })();
+
+export const dismissToast = (toastId?: string) => {
+  dispatch({
+    type: ActionType.DISMISS_TOAST,
+    toastId,
+  });
+  setTimeout(() => {
+    dispatch({
+      type: ActionType.REMOVE_TOAST,
+      toastId,
+    });
+  }, 1000);
+};

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,21 +1,6 @@
-import { dispatch, ActionType } from './store';
-
 export const genId = (() => {
   let count = 0;
   return () => {
     return (++count).toString();
   };
 })();
-
-export const dismissToast = (toastId?: string) => {
-  dispatch({
-    type: ActionType.DISMISS_TOAST,
-    toastId,
-  });
-  setTimeout(() => {
-    dispatch({
-      type: ActionType.REMOVE_TOAST,
-      toastId,
-    });
-  }, 1000);
-};


### PR DESCRIPTION
The `toast.dismiss(toastId)` function didn't work as intended (Auto-remove after 1 second by default).

The DOM tree of toast bars persist until the end of `duration` which would block the background elements during the time span. It's more noticeably if you have a long `duration`.

<img width="1116" alt="Screenshot 2020-12-30 at 11 57 01 AM" src="https://user-images.githubusercontent.com/22940472/103329801-75b24080-4a99-11eb-8ff9-00705d10682e.png">
