### PR TITLE
Wrap the getBoundingClientRect call in a setTimeout

### DIFF
--- a/src/components/toast-bar.tsx
+++ b/src/components/toast-bar.tsx
@@ -101,8 +101,10 @@ export const ToastBar: React.FC<ToastBarProps> = React.memo(
   ({ toast, position, ...props }) => {
     const ref = useCallback((el: HTMLElement | null) => {
       if (el) {
-        const boundingRect = el.getBoundingClientRect();
-        props.onHeight(boundingRect.height);
+        setTimeout(() => {
+          const boundingRect = el.getBoundingClientRect();
+          props.onHeight(boundingRect.height);
+        });
       }
     }, []);
 


### PR DESCRIPTION
By wrapping the getBoundingClientRect we defer the call to execute after Preact and React have successfully attached the dom element.

Fixes #27.