### PR TITLE
add missing className to example with all available options

### DIFF
--- a/site/pages/docs/toaster.mdx
+++ b/site/pages/docs/toaster.mdx
@@ -39,6 +39,7 @@ You can change the defaults for a specific type by adding, `success: {}`, `error
   position="top-center"
   reverseOrder={false}
   toastOptions={{
+    className: '',
     // Define default options
     style: {
       margin: '40px',

--- a/site/pages/docs/toaster.mdx
+++ b/site/pages/docs/toaster.mdx
@@ -39,8 +39,8 @@ You can change the defaults for a specific type by adding, `success: {}`, `error
   position="top-center"
   reverseOrder={false}
   toastOptions={{
-    className: '',
     // Define default options
+    className: '',
     style: {
       margin: '40px',
       background: '#363636',


### PR DESCRIPTION
`className` is missing from the 'example with all available options', this PR adds it.