### PR TITLE
Positioning wrapper div gets no pointer events

### DIFF
--- a/src/components/toast-bar.tsx
+++ b/src/components/toast-bar.tsx
@@ -64,7 +64,6 @@ const getPositionStyle = (
       }
     : {
         left: 0,
-        pointerEvents: 'none',
         right: 0,
         justifyContent: 'center',
       };
@@ -131,6 +130,7 @@ export const ToastBar: React.FC<ToastBarProps> = React.memo(
         style={{
           display: 'flex',
           zIndex: toast.visible ? 9999 : undefined,
+          pointerEvents: 'none',
           ...positionStyle,
         }}
       >
@@ -138,6 +138,7 @@ export const ToastBar: React.FC<ToastBarProps> = React.memo(
           ref={ref}
           className={toast.className}
           style={{
+            pointerEvents: 'initial',
             ...animationStyle,
             ...toast.style,
           }}


### PR DESCRIPTION
I need toasts to have a specific offset from their position, and can do that with a custom style that sets the `translate` CSS property. However because the wrapper `div` gets pointer events and sits at the original position, it "eats" pointer events.

This PR removes pointer events from the wrapper and then reinstates them on the div itself, so no functionality is lost.