### PR TITLE
Fix `undefined` id

### DIFF
--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -19,7 +19,6 @@ const createToast = (
   type: ToastType = 'blank',
   opts?: ToastOptions
 ): Toast => ({
-  id: opts?.id || genId(),
   createdAt: Date.now(),
   visible: true,
   type,
@@ -28,6 +27,7 @@ const createToast = (
   message,
   pauseDuration: 0,
   ...opts,
+  id: opts?.id || genId(),
 });
 
 const createHandler = (type?: ToastType): ToastHandler => (


### PR DESCRIPTION
I have a custom toast function which adds features to toast I need on a project. Simplified example:

```jsx
function customToast({ id ...props }) {
	return toast(
		(t) => (
			<CustomToast {...props} />
		),
		{
			id,
		},
	);
}
```

I works same as original toast — returns `id` to allow updating existing toast, or dismiss it.

```js
const id = customToast({ message: 'hey' }); //

customToast({ id, message: 'hi' };
```

However, in this example `id` is `undefined`. There is a fallback to `genId()`, but it gets overridden by `...opts`.

What happens is `id: opts?.id || genId()` receives `undefined` and sets fallback, but then `...opts` set `id` back to `undefined`.