### PR TITLE
Fix typo in Toaster docs

### DIFF
--- a/site/pages/docs/toaster.mdx
+++ b/site/pages/docs/toaster.mdx
@@ -13,7 +13,7 @@ This component will render all received toasts. Alternatively you can create own
 
 ### `position` Prop
 
-You can change the position of all toasts by modifieng supplying `positon` prop.
+You can change the position of all toasts by modifying supplying `positon` prop.
 
 | Positions   |               |              |
 | ----------- | ------------- | ------------ |


### PR DESCRIPTION
Does what it says on the tin - the word `modifying` was misspelled.