### PR TITLE
Keep track of dismissed toasts

### DIFF
--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -51,12 +51,6 @@ toast.dismiss = (toastId?: string) => {
     type: ActionType.DISMISS_TOAST,
     toastId,
   });
-  setTimeout(() => {
-    dispatch({
-      type: ActionType.REMOVE_TOAST,
-      toastId,
-    });
-  }, 1000);
 };
 
 toast.remove = (toastId?: string) =>


### PR DESCRIPTION
Store timeouts of dismissed toasts.
This should prevent toasts from beeing removed, after re-dispatched with the same ID.

Fixes #50