### PR TITLE
Update CSS import due to error

### DIFF
--- a/src/components/toaster.tsx
+++ b/src/components/toaster.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { setup } from 'goober';
-import CSS from 'csstype';
+import * as CSS from 'csstype';
 
 import { useToaster } from '../core/use-toaster';
 import { ToastBar } from './toast-bar';


### PR DESCRIPTION
This is the error I have been getting. It's not breaking but it's annoying

ERROR in [at-loader] ./node_modules/react-hot-toast/dist/components/toaster.d.ts:2:8
TS1192: Module '"/.../node_modules/csstype/index"' has no default export.

This is a minor fix that gets rid of it