### PR TITLE
docs: correct a typo

### DIFF
--- a/site/pages/docs/toast.mdx
+++ b/site/pages/docs/toast.mdx
@@ -182,7 +182,7 @@ toast(
 );
 ```
 
-You can also supply a function that receives the `Toast` as argument. This can be usefull to add a custom dismiss button.
+You can also supply a function that receives the `Toast` as argument. This can be useful to add a custom dismiss button.
 
 ```jsx
 toast(


### PR DESCRIPTION
"useful**l**" → "useful"