### PR TITLE
CSS fix for IE

### DIFF
--- a/src/components/toast-bar.tsx
+++ b/src/components/toast-bar.tsx
@@ -36,7 +36,7 @@ const Message = styled('div')`
   justify-content: center;
   margin: 4px 10px;
   color: inherit;
-  flex: 1;
+  flex: 1 1 auto;
 `;
 
 interface ToastBarProps {


### PR DESCRIPTION
It's a really simple CSS change that fixes the layout of the toast on IE (11).

Before:
![image](https://user-images.githubusercontent.com/3063279/117215670-d9a99480-adfe-11eb-940f-6f7bab44b996.png)

After:
![image](https://user-images.githubusercontent.com/3063279/117215676-db735800-adfe-11eb-84e6-88e1c7708792.png)
