### PR TITLE
Rollback default icon exports breaking change

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,9 @@ export { ToastBar } from './components/toast-bar';
 export { ToastIcon } from './components/toast-icon';
 export { Toaster } from './components/toaster';
 export { useStore as useToasterStore } from './core/store';
+export { CheckmarkIcon } from './components/checkmark';
+export { ErrorIcon } from './components/error';
+export { LoaderIcon } from './components/loader';
 export { resolveValue } from './core/types';
 
 export type ToastOptions = _ToastOptions;


### PR DESCRIPTION
Release v2.0 introduces a breaking change not noted by the docs whereby the `LoaderIcon`, `CheckmarkIcon` & `ErrorIcon` components are no longer exported by `react-hot-toast`. 

Use case: We are using these components elsewhere in our app for UI consistency. 
Breaking change: https://github.com/timolins/react-hot-toast/commit/25690e02e97050288672cabc6264663133674bfc#r52653621