### PR TITLE
Toasts not being read by NVDA

### DIFF
--- a/src/components/toaster.tsx
+++ b/src/components/toaster.tsx
@@ -87,6 +87,7 @@ export const Toaster: React.FC<ToasterProps> = ({
       className={containerClassName}
       onMouseEnter={handlers.startPause}
       onMouseLeave={handlers.endPause}
+      aria-live="polite"
     >
       {toasts.map((t) => {
         const toastPosition = t.position || position;


### PR DESCRIPTION
Fantastic library, thank you very much for building it!

I noticed whilst testing with NVDA that the toasts were not being spoken by the screen reader. I believe this is because aria-live regions need to be in the DOM on page load. 

This PR adds the aria-live="polite" attribute to the Toaster component which seems to resolve the issue with NVDA.