### PR TITLE
Make the `<ToastBar>` page title match the component name

### DIFF
--- a/site/pages/docs/toast-bar.mdx
+++ b/site/pages/docs/toast-bar.mdx
@@ -2,12 +2,12 @@ import Layout from '../../components/docs-layout';
 import toast from 'react-hot-toast';
 
 export const meta = {
-  title: '<ToasterBar/> API',
+  title: '<ToastBar/> API',
 };
 
 export default ({ children, meta }) => <Layout meta={meta}>{children}</Layout>;
 
-# `<ToasterBar />` API
+# `<ToastBar />` API
 
 This is the **default toast component** rendered by the [Toaster](/docs/toaster). You can use this component in a [Toaster](/docs/toaster) with a custom render function to overwrite its defaults.
 


### PR DESCRIPTION
The documentation page for `<ToastBar>` has a title of `<ToasterBar>` which doesn't match the component (or the rest of the page)