### PR TITLE
feat: add typings for toast custom props

### DIFF
--- a/site/pages/docs/toast.mdx
+++ b/site/pages/docs/toast.mdx
@@ -36,6 +36,11 @@ toast('Hello World', {
     role: 'status',
     'aria-live': 'polite',
   },
+
+  // Custom props that can be retrieve from `toast` Object
+  customProps: {
+    someCustomValue: 'Hello there general Custom Props',
+  },
 });
 ```
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -54,7 +54,7 @@ export interface Toast {
   height?: number;
 }
 
-export type ToastOptions = Partial<
+export type ToastOptions<C = {}> = Partial<
   Pick<
     Toast,
     | 'id'
@@ -66,12 +66,11 @@ export type ToastOptions = Partial<
     | 'position'
     | 'iconTheme'
   >
->;
+> & { customProps?: C };
 
-export type DefaultToastOptions = ToastOptions &
-  {
-    [key in ToastType]?: ToastOptions;
-  };
+export type DefaultToastOptions = ToastOptions & {
+  [key in ToastType]?: ToastOptions;
+};
 
 export interface ToasterProps {
   position?: ToastPosition;


### PR DESCRIPTION
### Information
First of all, thanks for this great library :) I'm currently implementing it in our system, and I notice I have a need to pass custom props in the `toast` method, so I can use them when rendering toasts. This already seems to be working, but types aren't covering this situation so I added them in this PR. What do you think?

