### PR TITLE
feat(Toaster, toast): #158 Support multiple, distinct Toasters by id

### DIFF
--- a/src/components/toaster.tsx
+++ b/src/components/toaster.tsx
@@ -53,6 +53,7 @@ export const Toaster: React.FC<ToasterProps> = ({
   children,
   containerStyle,
   containerClassName,
+  toasterId,
 }) => {
   const { toasts, handlers } = useToaster(toastOptions);
 
@@ -73,6 +74,8 @@ export const Toaster: React.FC<ToasterProps> = ({
       onMouseLeave={handlers.endPause}
     >
       {toasts.map((t) => {
+        if (t.toasterId !== toasterId) return;
+
         const toastPosition = t.position || position;
         const offset = handlers.calculateOffset(t, {
           reverseOrder,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -52,6 +52,8 @@ export interface Toast {
   createdAt: number;
   visible: boolean;
   height?: number;
+
+  toasterId?: string;
 }
 
 export type ToastOptions = Partial<
@@ -65,6 +67,7 @@ export type ToastOptions = Partial<
     | 'style'
     | 'position'
     | 'iconTheme'
+    | 'toasterId'
   >
 >;
 
@@ -80,5 +83,6 @@ export interface ToasterProps {
   gutter?: number;
   containerStyle?: React.CSSProperties;
   containerClassName?: string;
+  toasterId?: string;
   children?: (toast: Toast) => JSX.Element;
 }


### PR DESCRIPTION
# What

`<Toaster>` and `toast()` currently have no way of communicating
distinctly if there exists multiple Toaster elements throughout. Add a
way for toast calls to "pop up" exclusively from any specific Toaster

# Changes

Add `toasterId` to `<Toaster>` props

Add `toasterId` to all `toast*()` calls under the `options?` arg