### PR TITLE
Handle jsdom environments in Toaster when creating ref

### DIFF
--- a/src/components/toaster.tsx
+++ b/src/components/toaster.tsx
@@ -81,11 +81,12 @@ export const Toaster: React.FC<ToasterProps> = ({
         });
         const positionStyle = getPositionStyle(toastPosition, offset);
 
-        const ref = t.height != null
-          ? undefined
-          : createRectRef((rect) => {
-              handlers.updateHeight(t.id, rect.height);
-            });
+        const ref =
+          t.height != null
+            ? undefined
+            : createRectRef((rect) => {
+                handlers.updateHeight(t.id, rect.height);
+              });
 
         return (
           <div

--- a/src/components/toaster.tsx
+++ b/src/components/toaster.tsx
@@ -81,7 +81,7 @@ export const Toaster: React.FC<ToasterProps> = ({
         });
         const positionStyle = getPositionStyle(toastPosition, offset);
 
-        const ref = t.height
+        const ref = t.height != null
           ? undefined
           : createRectRef((rect) => {
               handlers.updateHeight(t.id, rect.height);


### PR DESCRIPTION
Fixes https://github.com/timolins/react-hot-toast/issues/107.

In jsdom the rect will always have a height of 0, causing an infinite loop due to the `t.height` check.

Fixed by checking for `t.height != null` instead. That way `0` will be considered a valid height value, but it'll still initialize correctly when `undefined` or `null`.