### PR TITLE
Docs: update version 2 page custom render api code example 

### DIFF
--- a/site/pages/docs/version-2.mdx
+++ b/site/pages/docs/version-2.mdx
@@ -150,7 +150,7 @@ This is a great alternative if you are using [`useToaster()`](/docs/use-toaster)
 This API allows us to dynamically react to to current state our toasts. This can be used to **change the default animations**, add **a custom dismiss button** or render a custom notification, like [TailwindUI Notifications](https://tailwindui.com/components/application-ui/overlays/notifications).
 
 ```jsx
-import { Toaster, ToastBar } from 'react-hot-toast';
+import { toast, Toaster, ToastBar } from 'react-hot-toast';
 
 const CustomToaster = () => (
   <Toaster>


### PR DESCRIPTION
The `toast` method was not imported but required for the `toast.dismiss()` function. I have updated the example code to import the method.