### PR TITLE
fix: csstype peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6029,9 +6029,9 @@
       "dev": true
     },
     "goober": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.1.tgz",
-      "integrity": "sha512-TkGCqHxE4g5DtdpwxFCi53bXRtvw0BoSgCihVSIOioe9kfkqin5wXG8BQKykN0tjzmxZJ81qU2KWinZf5qKVlw=="
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.9.tgz",
+      "integrity": "sha512-PAtnJbrWtHbfpJUIveG5PJIB6Mc9Kd0gimu9wZwPyA+wQUSeOeA4x4Ug16lyaaUUKZ/G6QEH1xunKOuXP1F4Vw=="
     },
     "graceful-fs": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "tsdx": "^0.14.1"
   },
   "dependencies": {
-    "goober": "^2.1.1"
+    "goober": "^2.1.9"
   }
 }


### PR DESCRIPTION
Small change to fix [this issue](https://github.com/timolins/react-hot-toast/issues/182).

[This release](https://github.com/cristianbote/goober/releases/tag/v2.1.8) contained the fix for the missing peer dependency.