### PR TITLE
Fix issue #190

### DIFF
--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -71,7 +71,10 @@ toast.promise = <T>(
   const id = toast.loading(msgs.loading, { ...opts, ...opts?.loading });
 
   promise
-    .then((p) => {
+    .then(async (p) => {
+      if (p instanceof Response && !p?.ok) {
+        throw Error(await p.text());
+      }
       toast.success(resolveValue(msgs.success, p), {
         id,
         ...opts,


### PR DESCRIPTION
If the server returns a Non-Ok HTTP status code (anything below 200 or above 299), then an error toast will be displayed. Not sure if the error should include the statusText (provides limited information), response text (might be too verbose?).

Note: I am not a typescript/javascript expert, kindly review and I would be happy to make more changes.