### PR TITLE
Website Example: Make snippet consistent with action

### DIFF
--- a/site/components/sections/toast-example.tsx
+++ b/site/components/sections/toast-example.tsx
@@ -143,7 +143,7 @@ const examples: Array<{
   {
     title: 'Themed',
     emoji: '🎨',
-    snippet: `toast.success('Look at me, I have brand styles.', {
+    snippet: `toast.success('Look at my styles.', {
   style: {
     border: '1px solid #713200',
     padding: '16px',


### PR DESCRIPTION
In the website, under the `Examples` section, the `Themed` toast triggered by the website has a source code different from the snippet - This commit fixes that.

https://github.com/timolins/react-hot-toast/blob/4a34354ad9a1cef6e6b9afd1eb9d6d06930224fc/site/components/sections/toast-example.tsx#L146
https://github.com/timolins/react-hot-toast/blob/4a34354ad9a1cef6e6b9afd1eb9d6d06930224fc/site/components/sections/toast-example.tsx#L158-L159

(I wasn't sure of which message to keep, so I just picked the shorter one)