### PR TITLE
Updated core/toast.ts

### DIFF
--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -74,7 +74,7 @@ toast.promise = <T>(
       toast.success(resolveValue(msgs.success, p), {
         id,
         ...opts,
-        ...opts?.success,
+        ...opts.success?.success,
       });
       return p;
     })
@@ -82,7 +82,7 @@ toast.promise = <T>(
       toast.error(resolveValue(msgs.error, e), {
         id,
         ...opts,
-        ...opts?.error,
+        ...opts.error?.error,
       });
     });
 


### PR DESCRIPTION
When promise is used, if success and error are not called in it, it will be displayed with an empty message I think this should be checked so that if an error or success is called in the promises, a toast is displayed.