### PR TITLE
Remove state from dep array of useStore's useEffect

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -188,7 +188,7 @@ export const useStore = (toastOptions: DefaultToastOptions = {}): State => {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   const mergedToasts = state.toasts.map((t) => ({
     ...toastOptions,


### PR DESCRIPTION
I couldn't figure out any obvious reason for why `state` was added in the dep array of the `useEffect` used in `useStore`, since it's not used inside it.

I removed it and everything keeps working as before (i.e. unit tests pass, manual testing seems just fine).

Actually, things got a bit better since the `useEffect` does not run for every `state` update.
It only runs once: on mount.

#### Before
The `useEffect` runs 7 times (for each subscriber) for the initial mount and all state transitions of a single toast.

https://user-images.githubusercontent.com/58694408/193424820-45e2c76f-29a0-4015-9c2b-11ca3fd46fb7.mp4


#### After
The `useEffect` runs 1 time (for each subscriber) only for the initial mount.

https://user-images.githubusercontent.com/58694408/193424823-b100a935-33f9-4d22-a3e2-d341b4844bb7.mp4


