### PR TITLE
expose the `dismiss` toast handler in useToaster hook

### DIFF
--- a/site/pages/docs/use-toaster.mdx
+++ b/site/pages/docs/use-toaster.mdx
@@ -14,7 +14,7 @@ The `useToaster()` hook provides you a **headless system that will manage the no
 It solves the following problems for you:
 
 - Built-in dispatch system with [`toast()`](/docs/toast)
-- Handlers to pause toasts on hover
+- Handlers to pause toasts on hover and dismiss them
 - Automatically remove expired toasts
 - Support for unmount animations. Removal is delayed by 1s, but sets `visible` on the toast to `false`.
 
@@ -43,7 +43,7 @@ import toast, { useToaster } from 'react-hot-toast/headless';
 
 const Notifications = () => {
   const { toasts, handlers } = useToaster();
-  const { startPause, endPause } = handlers;
+  const { startPause, endPause, dismiss } = handlers;
 
   return (
     <div onMouseEnter={startPause} onMouseLeave={endPause}>
@@ -52,6 +52,7 @@ const Notifications = () => {
         .map((toast) => (
           <div key={toast.id} {...toast.ariaProps}>
             {toast.message}
+            <button onClick={() => dismiss(toast.id)}x</button>
           </div>
         ))}
     </div>

--- a/site/pages/docs/use-toaster.mdx
+++ b/site/pages/docs/use-toaster.mdx
@@ -52,7 +52,7 @@ const Notifications = () => {
         .map((toast) => (
           <div key={toast.id} {...toast.ariaProps}>
             {toast.message}
-            <button onClick={() => dismiss(toast.id)}x</button>
+            <button onClick={() => dismiss(toast.id)}>x</button>
           </div>
         ))}
     </div>

--- a/src/core/use-toaster.ts
+++ b/src/core/use-toaster.ts
@@ -16,6 +16,8 @@ const startPause = () => {
   });
 };
 
+const dismiss = (toastId: string) => toast.dismiss(toastId);
+
 export const useToaster = (toastOptions?: DefaultToastOptions) => {
   const { toasts, pausedAt } = useStore(toastOptions);
 
@@ -91,6 +93,7 @@ export const useToaster = (toastOptions?: DefaultToastOptions) => {
       startPause,
       endPause,
       calculateOffset,
+      dismiss,
     },
   };
 };


### PR DESCRIPTION
I couldn't figure out if using the `useToaster` i could have a custom Notifications component that allows Toasts to be closed manually.

So i added the `dismiss` to the handlers object. This way, as detailed in the mdx file now, you could have a button in the Toast component that dismisses it. 

This brings it to parity with the alternative of using Toaster.

If there is a way and i didn't find it, please close this PR.

Cheers,
Cezar