### PR TITLE
fix: toast not appearing when toast.* called from useEffect hook

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { DefaultToastOptions, Toast, ToastType } from './types';
 
 const TOAST_LIMIT = 20;
@@ -180,7 +180,7 @@ export const defaultTimeouts: {
 
 export const useStore = (toastOptions: DefaultToastOptions = {}): State => {
   const [state, setState] = useState<State>(memoryState);
-  useEffect(() => {
+  useLayoutEffect(() => {
     listeners.push(setState);
     return () => {
       const index = listeners.indexOf(setState);

--- a/test/toast.test.tsx
+++ b/test/toast.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   render,
   screen,
@@ -113,6 +113,30 @@ test('promise toast', async () => {
   await waitFor(() => {
     expect(screen.queryByText(/success/i)).toBeInTheDocument();
   });
+});
+
+test('"toast" can be called from useEffect hook', async () => {
+  const WAIT_DELAY = 1000;
+
+  const MyComponent = () => {
+    const [success, setSuccess] = useState(false);
+    useEffect(() => {
+      toast.success("Success toast")
+      setSuccess(true);
+    }, []);
+
+    return success ? <div>MyComponent finished</div> : null;
+  }
+
+  render(
+    <>
+      <MyComponent />
+      <Toaster />
+    </>
+  );
+
+  await screen.findByText(/MyComponent finished/i);
+  expect(screen.queryByText(/Success toast/i)).toBeInTheDocument();
 });
 
 test('promise toast error', async () => {


### PR DESCRIPTION
### Issue
After calling a `toast.*` function from within a useEffect hook, the toast does not appear (see the new test case in toast.test.tsx for an example).

### Cause
The `useStore` hook (used by `Toaster`) calls "useState" to get the current state of the global `memoryState`, and then calls "useEffect" to set up a subscription to the global `memoryState`.

The bug is caused when a change to the global `memoryState` happens after "useState" is called, but before the "useEffect" callback is run. This can happen e.g. if we call a toast.* function from within another component's useEffect hook.

### Solution
To setup the global `memoryState` subscription, we use the "useLayoutEffect" hook instead. This hook runs the effect synchronously, so no change to the global `memoryState` can happen before the effect is run.

### Alternatives
`useSyncExternalStore` is a new hook that is designed to solve this problem and is built into React; we could use this hook instead: https://reactjs.org/docs/hooks-reference.html#usesyncexternalstore

### Related Github issues
https://github.com/timolins/react-hot-toast/issues/101
https://github.com/timolins/react-hot-toast/issues/57
https://github.com/timolins/react-hot-toast/issues/142