### PR TITLE
Fix: Replacing `loading` with `pending` in `toast.promise()`

### DIFF
--- a/site/pages/docs/toast.mdx
+++ b/site/pages/docs/toast.mdx
@@ -91,7 +91,7 @@ This shorthand is useful for mapping a promise to a toast. It will update automa
 const myPromise = fetchData();
 
 toast.promise(myPromise, {
-  loading: 'Loading',
+  pending: 'Loading',
   success: 'Got the data',
   error: 'Error when fetching',
 });
@@ -107,7 +107,7 @@ You can provide a function to the success/error messages to incorporate the resu
 toast.promise(
   myPromise,
   {
-    loading: 'Loading',
+    pending: 'Loading',
     success: (data) => `Successfully saved ${data.name}`,
     error: (err) => `This just happened: ${err.toString()}`,
   },
@@ -133,7 +133,7 @@ Every type has its own duration. You can overwrite them `duration` with the toas
 | `error`   | 4000     |
 | `success` | 2000     |
 | `custom`  | 4000     |
-| `loading` | Infinity |
+| `pending` | Infinity |
 
 ### Dismiss toast programmatically
 


### PR DESCRIPTION
When you call `toast.promise()` it doesn't recognize `loading` it takes `pending` as argument.

You can see in the following image


![image](https://user-images.githubusercontent.com/55713505/207524645-64280f6b-0626-43f3-874f-9efbb4dded76.png)

It only recognize three things:

- error
- pending
- success

That's why I am updating it in the docs.


PS. It was mistake by me this pull request was for another repo that's why I am closing it. 