### PR TITLE
Make csstype a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
     "@types/testing-library__jest-dom": "^5.14.5",
-    "csstype": "^3.1.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
     "prettier": "^2.7.1",
@@ -94,6 +93,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "csstype": "^3.1.1",
     "goober": "^2.1.10"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@types/react': ^18.0.15
   '@types/react-dom': ^18.0.6
   '@types/testing-library__jest-dom': ^5.14.5
-  csstype: ^3.1.0
+  csstype: ^3.1.1
   goober: ^2.1.10
   jest: ^28.1.3
   jest-environment-jsdom: ^28.1.3
@@ -23,7 +23,8 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  goober: 2.1.10_csstype@3.1.0
+  csstype: 3.1.1
+  goober: 2.1.10_csstype@3.1.1
 
 devDependencies:
   '@jest/types': 28.1.3
@@ -34,7 +35,6 @@ devDependencies:
   '@types/react': 18.0.15
   '@types/react-dom': 18.0.6
   '@types/testing-library__jest-dom': 5.14.5
-  csstype: 3.1.0
   jest: 28.1.3
   jest-environment-jsdom: 28.1.3
   prettier: 2.7.1
@@ -859,7 +859,7 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
-      csstype: 3.1.0
+      csstype: 3.1.1
     dev: true
 
   /@types/scheduler/0.16.2:
@@ -1315,8 +1315,8 @@ packages:
       cssom: 0.3.8
     dev: true
 
-  /csstype/3.1.0:
-    resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
+  /csstype/3.1.1:
+    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
 
   /data-urls/3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
@@ -1833,12 +1833,12 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /goober/2.1.10_csstype@3.1.0:
+  /goober/2.1.10_csstype@3.1.1:
     resolution: {integrity: sha512-7PpuQMH10jaTWm33sQgBQvz45pHR8N4l3Cu3WMGEWmHShAcTuuP7I+5/DwKo39fwti5A80WAjvqgz6SSlgWmGA==}
     peerDependencies:
       csstype: ^3.0.10
     dependencies:
-      csstype: 3.1.0
+      csstype: 3.1.1
     dev: false
 
   /graceful-fs/4.2.10:


### PR DESCRIPTION
Fixes #44.

Example of warning output:
> react-hot-toast@npm:2.4.0 [dc3fc] doesn't provide csstype (p01658), requested by goober