### PR TITLE
Feature optional msgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
 - ✅ **Accessible**
 - 🤯 **Headless Hooks** - _Create your own with [`useToaster()`](https://react-hot-toast.com/docs/use-toaster)_
 
+## Change logs
+* Added ability to toast promises with optional success and error message
+
 ## Installation
 
 #### With yarn

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "react-hot-toast",
+  "name": "@manojadams/react-hot-toast",
   "description": "Smoking hot React Notifications. Lightweight, customizable and beautiful by default.",
-  "version": "2.4.0",
+  "version": "2.4.6",
   "author": "Timo Lins",
   "license": "MIT",
-  "repository": "timolins/react-hot-toast",
+  "repository": "manojgetwealthy/react-hot-toast",
   "keywords": [
     "react",
     "notifications",
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "start": "tsup --watch",
-    "build": "tsup",
+    "build": "tsup --sourcemap inline",
     "test": "jest --runInBand",
     "setup": "pnpm i && cd site && pnpm i && cd .. && pnpm run link",
     "link": "pnpm link ./site/node_modules/react && pnpm link ./site/node_modules/react-dom",
@@ -53,6 +53,12 @@
     "singleQuote": true,
     "arrowParens": "always",
     "trailingComma": "es5"
+  },
+  "tsup": {
+    "entry": ["src/index.ts"],
+    "splitting": false,
+    "sourcemap": true,
+    "clean": true
   },
   "size-limit": [
     {

--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -62,8 +62,8 @@ toast.promise = <T>(
   promise: Promise<T>,
   msgs: {
     loading: Renderable;
-    success: ValueOrFunction<Renderable, T>;
-    error: ValueOrFunction<Renderable, any>;
+    success?: ValueOrFunction<Renderable, T>;
+    error?: ValueOrFunction<Renderable, any>;
   },
   opts?: DefaultToastOptions
 ) => {
@@ -71,7 +71,7 @@ toast.promise = <T>(
 
   promise
     .then((p) => {
-      toast.success(resolveValue(msgs.success, p), {
+      msgs.success && toast.success(resolveValue(msgs.success, p), {
         id,
         ...opts,
         ...opts?.success,
@@ -79,7 +79,7 @@ toast.promise = <T>(
       return p;
     })
     .catch((e) => {
-      toast.error(resolveValue(msgs.error, e), {
+      msgs.error && toast.error(resolveValue(msgs.error, e), {
         id,
         ...opts,
         ...opts?.error,

--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -84,7 +84,10 @@ toast.promise = <T>(
         ...opts,
         ...opts?.error,
       });
-    });
+    })
+    .finally(() => {
+      toast.remove(id);
+    })
 
   return promise;
 };


### PR DESCRIPTION
Hi Timolins,

This PR contains changes for the `toast.promise` function.

About:
Feature is added to use `toast.promise` without passing options for success and error message.

Usecase:
** It is a very common use case where someone wants to fetch some information (e.g: on a form submission) by making an api call and depending on the result, the user will be redirected to a different page.

While fetching information, we can show a `loading toaster` but after the results are obtained we don't want the user to show another toaster for 'success' msg and directly redirect the user to a different page based on the response.


Please let me know your feedback on this.