### PR TITLE
add note on toast width, addresses #110

### DIFF
--- a/site/pages/docs/styling.mdx
+++ b/site/pages/docs/styling.mdx
@@ -26,6 +26,8 @@ You can style your notifications globally with the `toastOptions` inside the Toa
 />
 ```
 
+Note that toasts have a default maximum width. If your message is cut off (e.g., when printing a large error message), you can set the `maxWidth` property in `style`, or, alternatively, add `wordBreak: 'break-all'`, to display more content.
+
 ### Set default for specific types
 
 ```jsx


### PR DESCRIPTION
This explains to users how to change the default style to make more content visible. By default, when rendering larger messages (like JSON validation errors or what have you), these are cut off. I was searching the docs for quite some time to find a simple solution, so this would have been helpful to have documented.