### PR TITLE
Fixed version 2.x documentation typo

### DIFF
--- a/site/pages/docs/version-2.mdx
+++ b/site/pages/docs/version-2.mdx
@@ -128,7 +128,7 @@ You can now use the [`<Toaster/>`](/docs/toaster#using-a-custom-render-function)
 
 This is a great alternative if you are using [`useToaster()`](/docs/use-toaster) to render create custom notfications.
 
-This API allows us to dynamically react to to current state our toasts. This can be used to **change the default animations**, add **a custom dismiss button** or render a custom notification, like [TailwindUI Notifications](https://tailwindui.com/components/application-ui/overlays/notifications).
+This API allows us to dynamically react to the current state of your toasts. This can be used to **change the default animations**, add **a custom dismiss button** or render a custom notification, like [TailwindUI Notifications](https://tailwindui.com/components/application-ui/overlays/notifications).
 
 ```jsx
 import { toast, Toaster, ToastBar } from 'react-hot-toast';


### PR DESCRIPTION
Very small PR fixes a simple typo in the Version 2.x documentation page