### PR TITLE
feat: `toast.promise(async () => {})`

### DIFF
--- a/site/pages/docs/toast.mdx
+++ b/site/pages/docs/toast.mdx
@@ -123,7 +123,9 @@ toast.promise(
 );
 ```
 
-#### Use Async Function
+#### Using an Async Function
+
+You can also provide a function that returns a promise, which will be called automatically.
 
 ```js
 toast.promise(

--- a/site/pages/docs/toast.mdx
+++ b/site/pages/docs/toast.mdx
@@ -123,6 +123,22 @@ toast.promise(
 );
 ```
 
+#### Use Async Function
+
+```js
+toast.promise(
+  async () => {
+    const { id } = await fetchData1();
+    await fetchData2(id);
+  },
+  {
+    loading: 'Loading',
+    success: 'Got the data',
+    error: 'Error when fetching',
+  }
+);
+```
+
 ## Default durations
 
 Every type has its own duration. You can overwrite them `duration` with the toast options. This can be done per toast options or globally by the [`<Toaster/>`](/docs/toaster).

--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -59,7 +59,7 @@ toast.remove = (toastId?: string) =>
   dispatch({ type: ActionType.REMOVE_TOAST, toastId });
 
 toast.promise = <T>(
-  promise: Promise<T>,
+  promise: Promise<T> | (() => Promise<T>),
   msgs: {
     loading: Renderable;
     success: ValueOrFunction<Renderable, T>;
@@ -68,6 +68,10 @@ toast.promise = <T>(
   opts?: DefaultToastOptions
 ) => {
   const id = toast.loading(msgs.loading, { ...opts, ...opts?.loading });
+
+  if (typeof promise === 'function') {
+    promise = promise();
+  }
 
   promise
     .then((p) => {


### PR DESCRIPTION
I wanted to use multiple awaits in `toast.promote`, but that was an error.
I implemented it so that it can be done.


```ts
toast.promise(
  async () => {
    await fetch();
    await fetch();
    await fetch();
  },
  {
    loading: 'Loading',
    success: 'Got the data',
    error: 'Error when fetching',
  }
);
```