### PR TITLE
chore: export Message and ToastHandler types

### DIFF
--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -6,13 +6,11 @@ import {
   DefaultToastOptions,
   ValueOrFunction,
   resolveValue,
+  Message,
+  ToastHandler,
 } from './types';
 import { genId } from './utils';
 import { dispatch, ActionType } from './store';
-
-type Message = ValueOrFunction<Renderable, Toast>;
-
-type ToastHandler = (message: Message, options?: ToastOptions) => string;
 
 const createToast = (
   message: Message,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -89,3 +89,7 @@ export interface ToastWrapperProps {
   onHeightUpdate: (id: string, height: number) => void;
   children?: React.ReactNode;
 }
+
+export type Message = ValueOrFunction<Renderable, Toast>;
+
+export type ToastHandler = (message: Message, options?: ToastOptions) => string;


### PR DESCRIPTION
I'm creating some custom functionality in my application that wraps several pieces of `react-hot-toast` and ran into an issue with Typescript where I had to recreate the `Message` and/or `ToastHandler` Types that already exist in the library.

I figured exporting those two types along with library might be a nice future-fix for anyone else running into the same issue.