### PR TITLE
Fix Issue #244

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -178,6 +178,11 @@ export const defaultTimeouts: {
   custom: 4000,
 };
 
+const defaultAriaProps = {
+  role: 'status',
+  'aria-live': 'polite',
+} as const;
+
 export const useStore = (toastOptions: DefaultToastOptions = {}): State => {
   const [state, setState] = useState<State>(memoryState);
   useEffect(() => {
@@ -191,6 +196,7 @@ export const useStore = (toastOptions: DefaultToastOptions = {}): State => {
   }, [state]);
 
   const mergedToasts = state.toasts.map((t) => ({
+    ariaProps: defaultAriaProps,
     ...toastOptions,
     ...toastOptions[t.type],
     ...t,

--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -22,10 +22,6 @@ const createToast = (
   createdAt: Date.now(),
   visible: true,
   type,
-  ariaProps: {
-    role: 'status',
-    'aria-live': 'polite',
-  },
   message,
   pauseDuration: 0,
   ...opts,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -40,7 +40,7 @@ export interface Toast {
   pauseDuration: number;
   position?: ToastPosition;
 
-  ariaProps: {
+  ariaProps?: {
     role: 'status' | 'alert';
     'aria-live': 'assertive' | 'off' | 'polite';
   };


### PR DESCRIPTION
## Summary
"toast" method's toast messages, using the "error" or "success" properties, do not apply the configured "ariaProps" options in the Toaster component. Please refer to the following link for more details.

https://github.com/timolins/react-hot-toast/issues/244

## Reason
When the "error" or "success" properties of the toast function are called, the createToast function is invoked. However, the issue lies in the fact that createToast defines default values for ariaProps.

```typescript
const createToast = (
  message: Message,
  type: ToastType = 'blank',
  opts?: ToastOptions
): Toast => ({
  createdAt: Date.now(),
  visible: true,
  type,
  ariaProps: {
    role: 'status',
    'aria-live': 'polite',
  },
  message,
  pauseDuration: 0,
  ...opts,
  id: opts?.id || genId(),
});
```

This value is causing an issue by overriding the globally set ariaProps option

## Solution
Firstly, I made ariaProps an optional property for the Toast type. ([62df748](https://github.com/timolins/react-hot-toast/pull/334/commits/62df7482ffb6cc2ef9fc3e17c184903d5faa8f30))

Secondly, within the createToast, I removed the ariaProps that were initially defined. ([7f85f4e](https://github.com/timolins/react-hot-toast/pull/334/commits/7f85f4ea838f1cd69dae1e5c28b38fee11dfc5b4))

Lastly, within the store, I created a variable named 'defaultAriaProps' to ensure default values are applied to ariaProps. (https://github.com/timolins/react-hot-toast/pull/334/commits/2949993d97926c892693d119accf7c71bd81bca9)
