### PR TITLE
feat: add optional "finally" callback after promise completion

### DIFF
--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -34,11 +34,11 @@ const createToast = (
 
 const createHandler =
   (type?: ToastType): ToastHandler =>
-  (message, options) => {
-    const toast = createToast(message, type, options);
-    dispatch({ type: ActionType.UPSERT_TOAST, toast });
-    return toast.id;
-  };
+    (message, options) => {
+      const toast = createToast(message, type, options);
+      dispatch({ type: ActionType.UPSERT_TOAST, toast });
+      return toast.id;
+    };
 
 const toast = (message: Message, opts?: ToastOptions) =>
   createHandler('blank')(message, opts);
@@ -64,6 +64,7 @@ toast.promise = <T>(
     loading: Renderable;
     success: ValueOrFunction<Renderable, T>;
     error: ValueOrFunction<Renderable, any>;
+    finally?: () => void;
   },
   opts?: DefaultToastOptions
 ) => {
@@ -84,7 +85,8 @@ toast.promise = <T>(
         ...opts,
         ...opts?.error,
       });
-    });
+    })
+    .finally(msgs.finally);
 
   return promise;
 };


### PR DESCRIPTION
The objective of this simple code increment is to allow execute some code ONLY after `promise.toast` completes its execution.

In my scenario it's useful to control UI elements that I want to keep disabled while the promise is running, disabling a button to be more specific, and reenabling the button with the "finally" callback, no matter if the promise resolves or rejects.

Example code:

```typescript
setIsCreatingTodo(true); // one UI button is disabled while todo is being created

toast.promise(createTodo()), {
  loading: 'Loading...',
  success: (createdTodo) => {
    gotoTodoViewer(createdTodo);
    return Translate('toast.done');
  },
  error: err => {
    const error = err as Error;
    return error.message;
  },
  finally: () => {
    setIsCreatingTodo(false);  // the button can be reactivated 
  }
});
```