### PR TITLE
Fix incorrect property name in docs

### DIFF
--- a/site/pages/docs/toaster.mdx
+++ b/site/pages/docs/toaster.mdx
@@ -32,7 +32,7 @@ This component will render all toasts. Alternatively you can create own renderer
     // Default options for specific types
     success: {
       duration: 3000,
-      theme: {
+      iconTheme: {
         primary: 'green',
         secondary: 'black',
       },


### PR DESCRIPTION
In `toaster.mdx` the property name `theme` is incorrect, it should be `iconTheme`.