### PR TITLE
Prepare for React 19

### DIFF
--- a/site/components/emoji-button.tsx
+++ b/site/components/emoji-button.tsx
@@ -1,6 +1,6 @@
 export const EmojiButton: React.FC<{
   onClick: () => void;
-  emoji: string | JSX.Element;
+  emoji: string | React.JSX.Element;
   children?: React.ReactNode;
 }> = ({ onClick, children, emoji }) => (
   <button

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -32,7 +32,7 @@ const Step: React.FC<{
   count: number;
   title: string;
   subTitle: string;
-  code: JSX.Element;
+  code: React.JSX.Element;
 }> = (props) => (
   <div className="flex flex-col gap-1 items-center">
     <div className="h-6 w-6 mb-2 text-sm rounded-full bg-toast-900 text-toast-50 flex items-center justify-center">

--- a/site/types/mdx.d.ts
+++ b/site/types/mdx.d.ts
@@ -1,4 +1,4 @@
 declare module '*.mdx' {
-  let MDXComponent: (props: any) => JSX.Element;
+  let MDXComponent: (props: any) => React.JSX.Element;
   export default MDXComponent;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,7 +9,7 @@ export type ToastPosition =
   | 'bottom-center'
   | 'bottom-right';
 
-export type Renderable = JSX.Element | string | null;
+export type Renderable = React.ReactElement | string | null;
 
 export interface IconTheme {
   primary: string;
@@ -79,7 +79,7 @@ export interface ToasterProps {
   gutter?: number;
   containerStyle?: React.CSSProperties;
   containerClassName?: string;
-  children?: (toast: Toast) => JSX.Element;
+  children?: (toast: Toast) => React.ReactElement;
 }
 
 export interface ToastWrapperProps {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,3 @@
-import { CSSProperties } from 'react';
-
 export type ToastType = 'success' | 'error' | 'loading' | 'blank' | 'custom';
 export type ToastPosition =
   | 'top-left'
@@ -45,7 +43,7 @@ export interface Toast {
     'aria-live': 'assertive' | 'off' | 'polite';
   };
 
-  style?: CSSProperties;
+  style?: React.CSSProperties;
   className?: string;
   iconTheme?: IconTheme;
 


### PR DESCRIPTION
The global `JSX` type is deprecated in React 18.3 and removed in React 19 RC. This PR changes the code to use the supported `React.JSX` syntax instead. It also changes from `JSX.Element` to the supported `React.ReactElement`.