### PR TITLE
docs: fix typo in toast.mdx

### DIFF
--- a/site/pages/docs/toast.mdx
+++ b/site/pages/docs/toast.mdx
@@ -107,7 +107,7 @@ It's recommend to add min-width to your `toast.promise()` calls to **prevent jum
 
 #### Advanced
 
-You can provide a function to the success/error messages to incorporate the result/error of the promise. The third argument are `toastOptions` similiar to [`<Toaster />`](/docs/toaster)
+You can provide a function to the success/error messages to incorporate the result/error of the promise. The third argument are `toastOptions` similar to [`<Toaster />`](/docs/toaster)
 
 ```js
 toast.promise(


### PR DESCRIPTION
"similiar" should to "similar"