### PR TITLE
docs: fix typo and grammar in toaster.mdx

### DIFF
--- a/site/pages/docs/toaster.mdx
+++ b/site/pages/docs/toaster.mdx
@@ -45,7 +45,7 @@ This component will render all toasts. Alternatively you can create own renderer
 
 ### `position` Prop
 
-You can change the position of all toasts by modifying supplying `positon` prop.
+You can change the position of all toasts by modifying supplying `position` prop.
 
 | Positions   |               |              |
 | ----------- | ------------- | ------------ |
@@ -54,15 +54,15 @@ You can change the position of all toasts by modifying supplying `positon` prop.
 
 ### `reverseOrder` Prop
 
-Toasts spawn at top by default. Set to `true` if you want new toasts at the end.
+Toasts spawn at the top by default. Set to `true` if you want new toasts at the end.
 
 ### `containerClassName` Prop
 
-Add a custom CSS class name to toaster div. Defaults to `undefined`.
+Add a custom CSS class name to the toaster div. Defaults to `undefined`.
 
 ### `containerStyle` Prop
 
-Customize the style of toaster div. This can be used to change the offset of all toasts
+Customize the style of the toaster div. This can be used to change the offset of all toasts
 
 ### `gutter` Prop
 


### PR DESCRIPTION
"positon" should to "position"