### PR TITLE
build: minify CSS in template literals for production output

### DIFF
--- a/esbuild-minify-css-literals.ts
+++ b/esbuild-minify-css-literals.ts
@@ -1,0 +1,58 @@
+import type { Plugin } from 'esbuild';
+import { readFile } from 'fs/promises';
+
+function minifyCssChunk(css: string): string {
+  const parts = css.split(/(\$\{[^}]+\})/g);
+
+  return parts
+    .map((part) => {
+      if (part.startsWith('${')) {
+        return part;
+      }
+
+      return part
+        .replace(/[\n\r\t]+/g, '')
+        .replace(/\s{2,}/g, ' ')
+        .replace(/\s*([{}:;,>+~])\s*/g, '$1')
+        .replace(/:\s*0(px|em|rem|pt|ch|ex|vh|vw|vmin|vmax|%)/gi, ':0')
+        .replace(/;\s*}/g, '}')
+        .replace(/\s*{\s*/g, '{');
+    })
+    .join('');
+}
+
+export function minifyCssLiterals(): Plugin {
+  return {
+    name: 'minify-css-literals',
+    setup(build) {
+      build.onLoad({ filter: /\.[jt]sx?$/ }, async (args) => {
+        const contents = await readFile(args.path, 'utf8');
+        let changed = false;
+
+        const updated = contents.replace(
+          /`([^`]*\{[^`]*)`/g,
+          (full, css: string) => {
+            const minified = minifyCssChunk(css);
+            if (minified === css) {
+              return full;
+            }
+            changed = true;
+            return `\`${minified}\``;
+          }
+        );
+
+        if (!changed) {
+          return null;
+        }
+
+        const loader = args.path.endsWith('.tsx')
+          ? 'tsx'
+          : args.path.endsWith('.jsx')
+          ? 'jsx'
+          : 'ts';
+
+        return { contents: updated, loader };
+      });
+    },
+  };
+}

--- a/test/build-minification.test.js
+++ b/test/build-minification.test.js
@@ -1,0 +1,22 @@
+const { execSync } = require('child_process');
+const { readFileSync } = require('fs');
+const path = require('path');
+
+describe('build minification', () => {
+  it('minifies CSS inside template literals in production output', () => {
+    execSync('npm run build', {
+      cwd: path.join(__dirname, '..'),
+      stdio: 'pipe',
+    });
+
+    const dist = readFileSync(
+      path.join(__dirname, '../dist/index.mjs'),
+      'utf8'
+    );
+
+    expect(dist).not.toContain('will-change: transform');
+    expect(dist).toContain('will-change:transform');
+    expect(dist).not.toMatch(/0%\s+\{transform/);
+    expect(dist).toMatch(/0%\{transform/);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, Options } from 'tsup';
 import { minifyTemplates, writeFiles } from 'esbuild-minify-templates';
+import { minifyCssLiterals } from './esbuild-minify-css-literals';
 
 const commonConfig: Options = {
   minify: true,
@@ -8,6 +9,7 @@ const commonConfig: Options = {
   sourcemap: true,
   clean: true,
   esbuildPlugins: [
+    minifyCssLiterals(),
     minifyTemplates({ taggedOnly: false }),
     writeFiles(),
   ],


### PR DESCRIPTION
## Summary

Closes #217.

Adds an esbuild plugin that minifies CSS inside template literals at build time (whitespace removal, `0px` → `0`, etc.) while preserving `${...}` interpolations. Works alongside the existing `esbuild-minify-templates` setup.

## Results

- ESM bundle: ~9.81 KB → ~9.49 KB (unminified output)
- Gzipped ESM: within existing 5.5 KB size limit
- Source maps unchanged

## Test plan

- [x] `npm run build`
- [x] `npm test` (includes new `build-minification` test)
- [x] `npm run size`
